### PR TITLE
Backported `ServerEngine::SignalThread` from serverengine v1.5.10

### DIFF
--- a/lib/perfectqueue.rb
+++ b/lib/perfectqueue.rb
@@ -41,6 +41,7 @@ module PerfectQueue
     :Worker => 'perfectqueue/worker',
     :Supervisor => 'perfectqueue/supervisor',
     :SignalQueue => 'perfectqueue/signal_queue',
+    :SignalThread => 'perfectqueue/signal_thread',
     :VERSION => 'perfectqueue/version',
   }.each_pair {|k,v|
     autoload k, File.expand_path(v, File.dirname(__FILE__))

--- a/lib/perfectqueue/multiprocess/child_process.rb
+++ b/lib/perfectqueue/multiprocess/child_process.rb
@@ -95,36 +95,37 @@ module PerfectQueue
 
       private
       def install_signal_handlers
-        SignalQueue.start do |sig|
-          sig.trap :TERM do
-            stop(false)
+        s = self
+        SignalThread.new do |st|
+          st.trap :TERM do
+            s.stop(false)
           end
-          sig.trap :INT do
-            stop(false)
-          end
-
-          sig.trap :QUIT do
-            stop(true)
+          st.trap :INT do
+            s.stop(false)
           end
 
-          sig.trap :USR1 do
-            stop(false)
+          st.trap :QUIT do
+            s.stop(true)
           end
 
-          sig.trap :HUP do
-            stop(true)
+          st.trap :USR1 do
+            s.stop(false)
           end
 
-          sig.trap :CONT do
-            stop(false)
+          st.trap :HUP do
+            s.stop(true)
           end
 
-          sig.trap :WINCH do
-            stop(true)
+          st.trap :CONT do
+            s.stop(false)
           end
 
-          sig.trap :USR2 do
-            logrotated
+          st.trap :WINCH do
+            s.stop(true)
+          end
+
+          st.trap :USR2 do
+            s.logrotated
           end
 
           trap :CHLD, "SIG_DFL"

--- a/lib/perfectqueue/signal_thread.rb
+++ b/lib/perfectqueue/signal_thread.rb
@@ -1,0 +1,127 @@
+#
+# PerfectQueue
+#
+# Copyright (C) 2012-2013 Sadayuki Furuhashi
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+module PerfectQueue
+
+  class SignalThread < Thread
+    def initialize(&block)
+      require 'thread'
+
+      @handlers = {}
+
+      @mutex = Mutex.new
+      @cond = ConditionVariable.new
+      @queue = []
+      @finished = false
+
+      block.call(self) if block
+
+      super(&method(:main))
+    end
+
+    def trap(sig, command=nil, &block)
+      # normalize signal names
+      sig = sig.to_s.upcase
+      if sig[0,3] == "SIG"
+        sig = sig[3..-1]
+      end
+      sig = sig.to_sym
+
+      old = @handlers[sig]
+      if block
+        Kernel.trap(sig) { signal_handler_main(sig) }
+        @handlers[sig] = block
+      else
+        Kernel.trap(sig, command)
+        @handlers.delete(sig)
+      end
+
+      old
+    end
+
+    def handlers
+      @handlers.dup
+    end
+
+    def stop
+      @mutex.synchronize do
+        @finished = true
+        @cond.broadcast
+      end
+      self
+    end
+
+    private
+
+    def signal_handler_main(sig)
+      # here always creates new thread to avoid
+      # complicated race condition in signal handlers
+      Thread.new do
+        begin
+          enqueue(sig)
+        rescue => e
+          STDERR.print "#{e}\n"
+          e.backtrace.each do |bt|
+            STDERR.print "\t#{bt}\n"
+            STDERR.flush
+          end
+        end
+      end
+
+    end
+
+    def main
+      until @finished
+        sig = nil
+
+        @mutex.synchronize do
+          while true
+            return if @finished
+
+            sig = @queue.shift
+            break if sig
+
+            @cond.wait(@mutex, 1)
+          end
+        end
+
+        begin
+          @handlers[sig].call(sig)
+        rescue => e
+          STDERR.print "#{e}\n"
+          e.backtrace.each do |bt|
+            STDERR.print "\t#{bt}\n"
+            STDERR.flush
+          end
+        end
+      end
+
+      nil
+
+    ensure
+      @finished = false
+    end
+
+    def enqueue(sig)
+      @mutex.synchronize do
+        @queue << sig
+        @cond.broadcast
+      end
+    end
+
+  end
+end

--- a/lib/perfectqueue/worker.rb
+++ b/lib/perfectqueue/worker.rb
@@ -99,30 +99,31 @@ module PerfectQueue
     end
 
     def install_signal_handlers
-      SignalQueue.start do |sig|
-        sig.trap :TERM do
-          stop(false)
+      s = self
+      SignalThread.new do |st|
+        st.trap :TERM do
+          s.stop(false)
         end
 
         # override
-        sig.trap :INT do
-          detach
+        st.trap :INT do
+          s.detach
         end
 
-        sig.trap :QUIT do
-          stop(true)
+        st.trap :QUIT do
+          s.stop(true)
         end
 
-        sig.trap :USR1 do
-          restart(false)
+        st.trap :USR1 do
+          s.restart(false)
         end
 
-        sig.trap :HUP do
-          restart(true)
+        st.trap :HUP do
+          s.restart(true)
         end
 
-        sig.trap :USR2 do
-          logrotated
+        st.trap :USR2 do
+          s.logrotated
         end
       end
     end


### PR DESCRIPTION
I confirmed that the `PerfectQueue::SignalQueue` cannot handle signals on Ruby 2.1.x. I found that Ruby 2.0+ doesn't allow to call `Mutex#lock` in `trap`.

To deal with, I backported `ServerEngine::SignalThread` from serverengine v1.5.10.

// We need to apply similar fix to `perfectsched` as well

