### PR TITLE
Change to better schema for MySQL

### DIFF
--- a/lib/perfectqueue/backend/rdb_compat.rb
+++ b/lib/perfectqueue/backend/rdb_compat.rb
@@ -125,18 +125,20 @@ SQL
       DEFAULT_DELETE_INTERVAL = 20
 
       def init_database(options)
-        sql = %[
+        table_sql = %[
             CREATE TABLE IF NOT EXISTS `#{@table}` (
-              id VARCHAR(256) NOT NULL,
+              id VARCHAR(255) NOT NULL,
               timeout INT NOT NULL,
-              data BLOB NOT NULL,
+              data LONGBLOB NOT NULL,
               created_at INT,
-              resource VARCHAR(256),
+              resource VARCHAR(255),
               max_running INT,
               PRIMARY KEY (id)
             );]
+        index_sql = "CREATE INDEX `index_#{@table}_on_timeout` ON `#{@table}` (`timeout`)"
         connect {
-          @db.run sql
+          @db.run table_sql
+          @db.run index_sql
         }
       end
 

--- a/perfectqueue.gemspec
+++ b/perfectqueue.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec", "~> 2.10.0"
   gem.add_development_dependency "simplecov", "~> 0.5.4"
   gem.add_development_dependency "sqlite3", "~> 1.3.3"
+  gem.add_development_dependency "mysql2", "~> 0.3.18"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ module QueueTest
         {
           :type => 'rdb_compat',
           :url => "sqlite://#{database_path}",
+          #:url => "mysql2://root:@localhost/test",
           :table => 'test_tasks',
           :processor_type => 'thread',
           :cleanup_interval => 0,  # for test
@@ -37,6 +38,7 @@ module QueueTest
 
       before do
         FileUtils.rm_f database_path
+        #queue.client.backend.instance_variable_get(:@db).run 'DROP TABLE IF EXISTS `test_tasks`'
         queue.client.init_database
       end
 


### PR DESCRIPTION
Currently, created schema by `init_database` is not better:

* should create index on `timeout` column
* it is better to use `varchar(255)` instead of `varchar(256)`
 * can not create `PRYAMRY KEY` when using charset `utf8` on `InnoDB` because max key length is 767 bytes on `InnoDB`

I think current schema by `init_database` on MySQL is not production ready, we should change `init_database`.