### PR TITLE
Avoid long range scan delete query

### DIFF
--- a/lib/perfectqueue/backend/rdb_compat.rb
+++ b/lib/perfectqueue/backend/rdb_compat.rb
@@ -223,7 +223,10 @@ SQL
 
         if @cleanup_interval_count <= 0
           connect_locked {
-            @db["DELETE FROM `#{@table}` WHERE timeout <= ? AND created_at IS NULL", now].delete
+            ids = @db.fetch("SELECT t.id AS id FROM (SELECT id, created_at FROM `#{@table}` WHERE timeout <= ? ORDER BY timeout DESC LIMIT 1000) t WHERE created_at IS NULL", now).map {|row| row[:id] }
+            unless ids.empty?
+              @db["DELETE FROM `#{@table}` WHERE id IN (#{(1..ids.size).map{'?'}.join(',')})", *ids].delete
+            end
             @cleanup_interval_count = @cleanup_interval
           }
         end


### PR DESCRIPTION
When queue is long, `timeout <= :now` condition is very expensive.
To avoiding long range scan by `ORDER BY timeout DESC` and `LIMIT`.