### PR TITLE
Avoid table metadata lock in MySQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ rvm:
 
 script: "bundle exec rake spec"
 
+before_script:
+  - mysql -e 'create database perfectqueue_test;'
+
 sudo: false
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -247,3 +247,13 @@ options for run:
 
     $ perfectqueue run -I. -Ilib -rconfig/boot.rb -rapps/workers/task_dispatch.rb TaskDispatch
 
+## Test
+
+Running spec utilize 'mysql2://root:@localhost/perfectqueue_test' as the connection string.
+Please install MySQL server at localhost then run;
+
+    $ mysql -h localhost -u root -e 'create database perfectqueue_test;'
+
+You can run spec.
+
+    $ bundle exec rake spec

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+machine:
+  ruby:
+    version: 2.2.2
+
+database:
+  pre:
+    - mysql -e 'create database perfectqueue_test;'

--- a/lib/perfectqueue/backend/rdb_compat.rb
+++ b/lib/perfectqueue/backend/rdb_compat.rb
@@ -168,8 +168,7 @@ SQL
         now = (options[:now] || Time.now).to_i
 
         connect {
-          #@db.fetch("SELECT id, timeout, data, created_at, resource FROM `#{@table}` WHERE !(created_at IS NULL AND timeout <= ?) ORDER BY timeout ASC;", now) {|row|
-          @db.fetch("SELECT id, timeout, data, created_at, resource, max_running FROM `#{@table}` ORDER BY timeout ASC", now) {|row|
+          @db.fetch("SELECT id, timeout, data, created_at, resource, max_running FROM `#{@table}` ORDER BY timeout ASC") {|row|
             attributes = create_attributes(now, row)
             task = TaskWithMetadata.new(@client, row[:id], attributes)
             yield task

--- a/lib/perfectqueue/backend/rdb_compat.rb
+++ b/lib/perfectqueue/backend/rdb_compat.rb
@@ -125,18 +125,21 @@ SQL
       DEFAULT_DELETE_INTERVAL = 20
 
       def init_database(options)
-        sql = %[
-            CREATE TABLE IF NOT EXISTS `#{@table}` (
-              id VARCHAR(256) NOT NULL,
-              timeout INT NOT NULL,
-              data BLOB NOT NULL,
-              created_at INT,
-              resource VARCHAR(256),
-              max_running INT,
-              PRIMARY KEY (id)
-            );]
+        sql = []
+        sql << <<-SQL
+          CREATE TABLE IF NOT EXISTS `#{@table}` (
+            id VARCHAR(255) NOT NULL,
+            timeout INT NOT NULL,
+            data LONGBLOB NOT NULL,
+            created_at INT,
+            resource VARCHAR(255),
+            max_running INT,
+            PRIMARY KEY (id)
+          )
+          SQL
+        sql << "CREATE INDEX `index_#{@table}_on_timeout` ON `#{@table}` (`timeout`)"
         connect {
-          @db.run sql
+          sql.each(&@db.method(:run))
         }
       end
 

--- a/lib/perfectqueue/backend/rdb_compat.rb
+++ b/lib/perfectqueue/backend/rdb_compat.rb
@@ -81,7 +81,7 @@ LIMIT ?
 SQL
         else
           @sql = <<SQL
-SELECT id, timeout, data, created_at, resource, max_running, max_running/running AS weight
+SELECT id, timeout, data, created_at, resource, max_running, IFNULL(max_running, 1) / (IFNULL(running, 0) + 1) AS weight
 FROM `#{@table}`
 LEFT JOIN (
   SELECT resource AS res, COUNT(1) AS running
@@ -90,7 +90,7 @@ LEFT JOIN (
   GROUP BY resource
 ) AS R ON resource = res
 WHERE timeout <= ? AND created_at IS NOT NULL AND (max_running-running IS NULL OR max_running-running > 0)
-ORDER BY weight IS NOT NULL, weight DESC, timeout ASC
+ORDER BY weight DESC, timeout ASC
 LIMIT ?
 SQL
         end

--- a/lib/perfectqueue/backend/rdb_compat.rb
+++ b/lib/perfectqueue/backend/rdb_compat.rb
@@ -207,7 +207,7 @@ SQL
 
         connect {
           begin
-            n = @db[
+            @db[
               "INSERT INTO `#{@table}` (id, timeout, data, created_at, resource, max_running) VALUES (?, ?, ?, ?, ?, ?)",
               key, run_at, d, now, user, max_running
             ].insert
@@ -441,7 +441,7 @@ SQL
           type = row[:id].split(/\./, 2)[0]
         end
 
-        attributes = {
+        {
           :status => status,
           :created_at => created_at,
           :data => data,

--- a/lib/perfectqueue/backend/rdb_compat.rb
+++ b/lib/perfectqueue/backend/rdb_compat.rb
@@ -126,6 +126,7 @@ SQL
 
       def init_database(options)
         sql = []
+        sql << "DROP TABLE IF EXISTS `#{@table}`" if options[:force]
         sql << <<-SQL
           CREATE TABLE IF NOT EXISTS `#{@table}` (
             id VARCHAR(255) NOT NULL,

--- a/lib/perfectqueue/backend/rdb_compat.rb
+++ b/lib/perfectqueue/backend/rdb_compat.rb
@@ -109,16 +109,8 @@ SQL
               end
               break if locked
             end
-            # TODO: We will remove the following locking
-            if config[:disable_resource_limit]
-              @db.run("LOCK TABLES `#{@table}` WRITE")
-            else
-              @db.run("LOCK TABLES `#{@table}` WRITE, `#{@table}` AS T WRITE")
-            end
           }
           @table_unlock = lambda {
-            # TODO: We will remove the following unlocking
-            @db.run("UNLOCK TABLES")
             @db.run("SELECT RELEASE_LOCK('#{@table}')")
           }
         else

--- a/perfectqueue.gemspec
+++ b/perfectqueue.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec", "~> 2.10.0"
   gem.add_development_dependency "simplecov", "~> 0.10.0"
   gem.add_development_dependency "sqlite3", "~> 1.3.3"
+  gem.add_development_dependency "mysql2", "~> 0.3.20"
 end

--- a/spec/rdb_compat_backend_spec.rb
+++ b/spec/rdb_compat_backend_spec.rb
@@ -2,12 +2,7 @@ require 'spec_helper'
 require 'perfectqueue/backend/rdb_compat'
 
 describe Backend::RDBCompatBackend do
-  let :queue do
-    FileUtils.rm_f 'spec/test.db'
-    queue = PerfectQueue.open({:type=>'rdb_compat', :url=>'sqlite://spec/test.db', :table=>'test_tasks', :processor_type=>'thread'})
-    queue.client.init_database
-    queue
-  end
+  include QueueTest
 
   let :client do
     queue.client

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,14 +21,10 @@ require 'fileutils'
 module QueueTest
   def self.included(mod)
     mod.module_eval do
-      let :database_path do
-        'spec/test.db'
-      end
-
       let :queue_config do
         {
           :type => 'rdb_compat',
-          :url => "sqlite://#{database_path}",
+          :url => "mysql2://root:@localhost/perfectqueue_test",
           :table => 'test_tasks',
           :processor_type => 'thread',
           :cleanup_interval => 0,  # for test
@@ -41,8 +37,7 @@ module QueueTest
       end
 
       before do
-        FileUtils.rm_f database_path
-        queue.client.init_database
+        queue.client.init_database(:force => true)
       end
 
       after do


### PR DESCRIPTION
`LOCK TABLES` causes `Waiting for table metadata lock` contention issue.
It is better to use `GET_LOCK` instead of `LOCK TABLES` in MySQL.