### PR TITLE
Remove dump of task request:

### DIFF
--- a/lib/perfectqueue/multiprocess/thread_processor.rb
+++ b/lib/perfectqueue/multiprocess/thread_processor.rb
@@ -121,7 +121,7 @@ module PerfectQueue
       end
 
       def process(task)
-        @log.info "acquired task task=#{task.key} id=#{@processor_id}: #{task.inspect}"
+        @log.info "acquired task task=#{task.key} id=#{@processor_id}"
         begin
           r = @runner.new(task)
           @tm.set_task(task, r)


### PR DESCRIPTION
* In real application, its too huge to read, and also danger to dump all data for task in logs