### PR TITLE
UPDATE first strategy for finer grained locking

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+== 2016-xx-xx version 0.9.0
+
+* Use UPDATE first strategy (#15)
+  * owner column is added for the table: migration is required
+  * AcquiredTask#timeout is the current value rather than at acquiring
+  * prefetch_break_types is removed
+
 == 2016-08-02 version 0.8.49
 
 * Revert v0.8.44 migration path (#38)

--- a/lib/perfectqueue/backend/rdb_compat.rb
+++ b/lib/perfectqueue/backend/rdb_compat.rb
@@ -75,34 +75,56 @@ module PerfectQueue
           # connection test
         }
 
+        # MySQL's CONNECTION_ID() is a 64bit unsigned integer from the
+        # server's internal thread ID counter. It is unique while the MySQL
+        # server is running.
+        # https://bugs.mysql.com/bug.php?id=19806
+        #
+        # An acquired task is marked with next_timeout and CONNECTION_ID().
+        # Therefore while alive_time is not changed and we don't restart
+        # the server in 1 second, they won't conflict.
         if config[:disable_resource_limit]
+          @update_sql = <<SQL
+UPDATE `#{@table}`
+  JOIN (
+  SELECT id
+    FROM `#{@table}` FORCE INDEX (`index_#{@table}_on_timeout`)
+   WHERE #{EVENT_HORIZON} < timeout AND timeout <= :now
+   ORDER BY timeout ASC
+      LIMIT :max_acquire FOR UPDATE) AS t1 USING(id)
+   SET timeout=:next_timeout, owner=CONNECTION_ID()
+SQL
           @sql = <<SQL
 SELECT id, timeout, data, created_at, resource
-FROM `#{@table}`
-WHERE #{EVENT_HORIZON} < timeout AND timeout <= ? AND timeout <= ?
-      AND created_at IS NOT NULL
-ORDER BY timeout ASC
-LIMIT ?
+  FROM `#{@table}`
+ WHERE timeout = ? AND owner = CONNECTION_ID()
 SQL
         else
+          @update_sql = <<SQL
+UPDATE `#{@table}`
+  JOIN (
+    SELECT id, IFNULL(max_running, 1) / (IFNULL(running, 0) + 1) AS weight
+    FROM `#{@table}`
+    LEFT JOIN (
+      SELECT resource, COUNT(1) AS running
+      FROM `#{@table}` AS t1
+      WHERE timeout > :now AND resource IS NOT NULL
+      GROUP BY resource
+      FOR UPDATE
+    ) AS t2 USING(resource)
+    WHERE #{EVENT_HORIZON} < timeout AND timeout <= :now AND IFNULL(max_running - running, 1) > 0
+    ORDER BY weight DESC, timeout ASC
+    LIMIT :max_acquire
+    FOR UPDATE
+  ) AS t3 USING (id)
+SET timeout = :next_timeout, owner = CONNECTION_ID()
+SQL
           @sql = <<SQL
-SELECT id, timeout, data, created_at, resource, max_running, IFNULL(max_running, 1) / (IFNULL(running, 0) + 1) AS weight
-FROM `#{@table}`
-LEFT JOIN (
-  SELECT resource AS res, COUNT(1) AS running
-  FROM `#{@table}` AS T
-  WHERE timeout > ? AND created_at IS NOT NULL AND resource IS NOT NULL
-  GROUP BY resource
-) AS R ON resource = res
-WHERE #{EVENT_HORIZON} < timeout AND timeout <= ?
-      AND created_at IS NOT NULL
-      AND (max_running-running IS NULL OR max_running-running > 0)
-ORDER BY weight DESC, timeout ASC
-LIMIT ?
+SELECT id, timeout, data, created_at, resource, max_running
+  FROM `#{@table}`
+ WHERE timeout = ? AND owner = CONNECTION_ID()
 SQL
         end
-
-        @prefetch_break_types = config[:prefetch_break_types] || []
 
         @cleanup_interval = config[:cleanup_interval] || DEFAULT_DELETE_INTERVAL
         # If cleanup_interval > max_request_per_child / max_acquire,
@@ -129,6 +151,8 @@ SQL
             created_at INT,
             resource VARCHAR(255),
             max_running INT,
+            /* CONNECTION_ID() can be 64bit: https://bugs.mysql.com/bug.php?id=19806 */
+            owner BIGINT(21) UNSIGNED NOT NULL DEFAULT 0,
             PRIMARY KEY (id)
           )
           SQL
@@ -219,7 +243,7 @@ SQL
         t0 = nil
 
         if @cleanup_interval_count <= 0
-          connect { # TODO: HERE should be still connect_locked ?
+          connect {
             t0=Process.clock_gettime(Process::CLOCK_MONOTONIC)
             @db["DELETE FROM `#{@table}` WHERE timeout <= ?", now-DELETE_OFFSET].delete
             @cleanup_interval_count = @cleanup_interval
@@ -229,34 +253,18 @@ SQL
 
         connect_locked {
           t0=Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          n = @db[@update_sql, next_timeout: next_timeout, now: now, max_acquire: max_acquire].update
+          if n <= 0
+            return nil
+          end
+
           tasks = []
-          @db.fetch(@sql, now, now, max_acquire) {|row|
+          @db.fetch(@sql, next_timeout) {|row|
             attributes = create_attributes(nil, row)
             task_token = Token.new(row[:id])
             task = AcquiredTask.new(@client, row[:id], attributes, task_token)
             tasks.push task
-
-            if @prefetch_break_types.include?(attributes[:type])
-              break
-            end
           }
-
-          if tasks.empty?
-            return nil
-          end
-
-          sql = "UPDATE `#{@table}` FORCE INDEX (PRIMARY) SET timeout=? WHERE timeout <= ? AND id IN ("
-          params = [sql, next_timeout, now]
-          tasks.each {|t| params << t.key }
-          sql << (1..tasks.size).map { '?' }.join(',')
-          sql << ") AND created_at IS NOT NULL"
-
-          n = @db[*params].update
-          if n != tasks.size
-            # NOTE table lock doesn't work. error!
-            return nil
-          end
-
           @cleanup_interval_count -= 1
 
           return tasks


### PR DESCRIPTION
To acquire tasks, run UPDATE and SELECT instead of SELECT and UPDATE.

This adds a new column `owner` to identify which connection acquires the task.
With this column, `RDBCompatBackend#acquire` now doesn't get table lock nor use
`GET_LOCK()`, but adopt mark-and-select method.
It locks only oldest N rows and their gaps during UPDATE.

CONNECTION_ID()
---------------

64bit unsigned integer from the server's internal thread ID counter.
This is unique while the MySQL server running.
http://dev.mysql.com/doc/refman/5.6/en/information-functions.html#function_connection-id
https://bugs.mysql.com/bug.php?id=19806

References
---------------

* http://yuuki.hatenablog.com/entry/go-and-mysql-jobqueue
* https://blog.engineyard.com/2011/5-subtle-ways-youre-using-mysql-as-a-queue-and-why-itll-bite-you

Migration plan
---------------

* Add `owner` column
* clean up created_at related code
* use connect_locked on acquire during migration.