### PR TITLE
Remove useless transaction

### DIFF
--- a/lib/perfectqueue/backend/rdb_compat.rb
+++ b/lib/perfectqueue/backend/rdb_compat.rb
@@ -333,15 +333,12 @@ SQL
           locked = false
 
           begin
-            @db.transaction do
-              if @table_lock
-                @table_lock.call
-                locked = true
-              end
-
-              return block.call
+            if @table_lock
+              @table_lock.call
+              locked = true
             end
 
+            return block.call
           ensure
             if @use_connection_pooling && locked
               @table_unlock.call


### PR DESCRIPTION
In the old days it uses `SELECT FOR UPDATE` and require transaction.
But these days it introduces `LOCK TABLES` and `GET_LOCK()` and don't
need transaction.