### PR TITLE
Separate delete and acquire queries

### DIFF
--- a/lib/perfectqueue/backend/rdb_compat.rb
+++ b/lib/perfectqueue/backend/rdb_compat.rb
@@ -67,7 +67,7 @@ module PerfectQueue
             end
           }
           @table_unlock = lambda {
-            @db.run("SELECT RELEASE_LOCK('#{@table}')")
+            @db.run("DO RELEASE_LOCK('#{@table}')")
           }
         else
           raise ConfigError, "only 'mysql' is supported"

--- a/spec/rdb_compat_backend_spec.rb
+++ b/spec/rdb_compat_backend_spec.rb
@@ -275,7 +275,7 @@ describe Backend::RDBCompatBackend do
     let (:key){ 'key' }
     let (:task_token){ Backend::RDBCompatBackend::Token.new(key) }
     let (:retention_time) { 42 }
-    let (:delete_timeout){ now + retention_time }
+    let (:delete_timeout){ now - Backend::RDBCompatBackend::DELETE_OFFSET + retention_time }
     let (:options){ {now: now} }
     context 'have the task' do
       before do


### PR DESCRIPTION
* Separate the area where a DELETE query locks from the area where
  acquire query touchs. By this change DELETE query and acquire query
  can run parallel.
** finished task was SET timeout=now+retention_time, created_at=NULL.
   This intoroduces DELETE_OFFSET=10_0000_0000, and change as
   SET timeout=now-DELETE_OFFSET+retention_time, created_at=NULL.
** To separate tasks to be acquired from tasks to be deleted,
   introduce EVENT_HORIZON(=13_0000_0000, 2011-03-13 07:06:40 UTC).
   Now it doesn't check prior that.

NOTE: this change requires migration process like actual DELETE query
see WHERE timeout <= now AND created_at IS NULL.
