### PR TITLE
Use DO Syntax for RELEASE_LOCK()

### DIFF
--- a/lib/perfectqueue/backend/rdb_compat.rb
+++ b/lib/perfectqueue/backend/rdb_compat.rb
@@ -67,7 +67,7 @@ module PerfectQueue
             end
           }
           @table_unlock = lambda {
-            @db.run("SELECT RELEASE_LOCK('#{@table}')")
+            @db.run("DO RELEASE_LOCK('#{@table}')")
           }
         else
           raise ConfigError, "only 'mysql' is supported"


### PR DESCRIPTION
Manual says "The DO statement is convenient to use with RELEASE_LOCK()."
https://dev.mysql.com/doc/refman/5.6/en/miscellaneous-functions.html#function_release-lock