### PR TITLE
Add a stress test for long waiting queue

### DIFF
--- a/spec/rdb_stress.rb
+++ b/spec/rdb_stress.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+require 'perfectqueue/backend/rdb_compat'
+require 'logger'
+
+# run this with `bundle exec rake spec SPEC_OPTS="-fd" SPEC=spec/rdb_stress.rb`
+
+describe Backend::RDBCompatBackend do
+  let (:now){ Time.now.to_i }
+  let (:client){ double('client') }
+  let (:table){ 'test_queues' }
+  let (:config){ {
+    url: 'mysql2://root:@localhost/perfectqueue_test',
+    table: table,
+    disable_resource_limit: true,
+  } }
+  let (:db) do
+    d = Backend::RDBCompatBackend.new(client, config)
+    s = d.db
+    s.tables.each{|t| s.drop_table(t) }
+    d.init_database({})
+    d
+  end
+
+  context '#acquire' do
+    let (:task_token){ Backend::RDBCompatBackend::Token.new(key) }
+    let (:alive_time){ 42 }
+    let (:max_acquire){ 10 }
+    context 'some tasks' do
+      before do
+        sql = nil
+        bucket_size = 200000
+        600_000.times do |i|
+          if i % bucket_size == 0
+            sql = 'INSERT `test_queues` (id, timeout, data, created_at, resource) VALUES'
+          end
+          t = now - 600 + i/1000
+          sql << "(UUID(),#{t},TO_BASE64(RANDOM_BYTES(540)),#{t},NULL),"
+          if i % bucket_size == bucket_size - 1
+            db.db.run sql.chop!
+          end
+        end
+        db.db.loggers << Logger.new($stderr)
+        db.db.sql_log_level = :debug
+      end
+      it 'returns a task' do
+        #db.instance_variable_set(:@cleanup_interval_count, 0)
+        #expect(db.db.instance_variable_get(:@default_dataset)).to receive(:delete).and_call_original
+        ary = db.acquire(alive_time, max_acquire, {})
+        expect(ary).to be_an_instance_of(Array)
+        expect(ary.size).to eq(10)
+        expect(ary[0]).to be_an_instance_of(AcquiredTask)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Also note that with master, it works fine with 6M waiting tasks.

With v0.8.45:

PerfectQueue::Backend::RDBCompatBackend
  #acquire
    some tasks
D, [2016-03-07T17:30:47.700983 #35536] DEBUG -- : (0.000104s) SET @@wait_timeout = 2147483
D, [2016-03-07T17:30:47.701119 #35536] DEBUG -- : (0.000062s) SET SQL_AUTO_IS_NULL=0
D, [2016-03-07T17:30:47.701310 #35536] DEBUG -- : (0.000066s) BEGIN
D, [2016-03-07T17:30:47.701497 #35536] DEBUG -- : (0.000116s) SELECT GET_LOCK('test_queues', 60) locked
D, [2016-03-07T17:30:49.155729 #35536] DEBUG -- : (1.454003s) DELETE FROM `test_queues` WHERE timeout <= 1457339447 AND created_at IS NULL
D, [2016-03-07T17:30:49.157869 #35536] DEBUG -- : (0.002047s) COMMIT
D, [2016-03-07T17:30:49.158730 #35536] DEBUG -- : (0.000071s) SET @@wait_timeout = 2147483
D, [2016-03-07T17:30:49.158821 #35536] DEBUG -- : (0.000054s) SET SQL_AUTO_IS_NULL=0
D, [2016-03-07T17:30:49.158969 #35536] DEBUG -- : (0.000065s) BEGIN
D, [2016-03-07T17:30:49.159150 #35536] DEBUG -- : (0.000097s) SELECT GET_LOCK('test_queues', 60) locked
D, [2016-03-07T17:30:49.160148 #35536] DEBUG -- : (0.000883s) SELECT id, timeout, data, created_at, resource
FROM `test_queues`
WHERE timeout <= 1457339447 AND timeout <= 1457339447 AND created_at IS NOT NULL
ORDER BY timeout ASC
LIMIT 10

D, [2016-03-07T17:30:49.163366 #35536] DEBUG -- : (0.000484s) UPDATE `test_queues` SET timeout=1457339489 WHERE id IN ('d84f215c-e43e-11e5-91d1-61143f034f84','d84f265c-e43e-11e5-91d1-61143f034f84','d84f27a6-e43e-11e5-91d1-61143f034f84','d84f288c-e43e-11e5-91d1-61143f034f84','d84f295e-e43e-11e5-91d1-61143f034f84','d84f2a30-e43e-11e5-91d1-61143f034f84','d84f2b02-e43e-11e5-91d1-61143f034f84','d84f2bca-e43e-11e5-91d1-61143f034f84','d84f2c9c-e43e-11e5-91d1-61143f034f84','d84f2d6e-e43e-11e5-91d1-61143f034f84') AND created_at IS NOT NULL
D, [2016-03-07T17:30:49.164744 #35536] DEBUG -- : (0.001296s) COMMIT
      returns a task

Finished in 23.11 seconds (files took 0.08405 seconds to load)
1 example, 0 failures

With master:

PerfectQueue::Backend::RDBCompatBackend
  #acquire
    some tasks
2016-03-07 17:29:20 +0900
D, [2016-03-07T17:29:20.950600 #35395] DEBUG -- : (0.000098s) SET @@wait_timeout = 2147483
D, [2016-03-07T17:29:20.950776 #35395] DEBUG -- : (0.000088s) SET SQL_AUTO_IS_NULL=0
D, [2016-03-07T17:29:20.951411 #35395] DEBUG -- : (0.000565s) DELETE FROM `test_queues` WHERE timeout <= 457339360 AND created_at IS NULL
D, [2016-03-07T17:29:20.952186 #35395] DEBUG -- : (0.000070s) SET @@wait_timeout = 2147483
D, [2016-03-07T17:29:20.952294 #35395] DEBUG -- : (0.000068s) SET SQL_AUTO_IS_NULL=0
D, [2016-03-07T17:29:20.952502 #35395] DEBUG -- : (0.000155s) SELECT GET_LOCK('test_queues', 60) locked
D, [2016-03-07T17:29:20.953715 #35395] DEBUG -- : (0.001059s) SELECT id, timeout, data, created_at, resource
FROM `test_queues`
WHERE 1300000000 < timeout AND timeout <= 1457339360 AND timeout <= 1457339360
      AND created_at IS NOT NULL
ORDER BY timeout ASC
LIMIT 10

D, [2016-03-07T17:29:20.958264 #35395] DEBUG -- : (0.001690s) UPDATE `test_queues` SET timeout=1457339402 WHERE id IN ('a45c3d9e-e43e-11e5-91d1-61143f034f84','a45c4348-e43e-11e5-91d1-61143f034f84','a45c44ba-e43e-11e5-91d1-61143f034f84','a45c45a0-e43e-11e5-91d1-61143f034f84','a45c467c-e43e-11e5-91d1-61143f034f84','a45c4758-e43e-11e5-91d1-61143f034f84','a45c482a-e43e-11e5-91d1-61143f034f84','a45c48fc-e43e-11e5-91d1-61143f034f84','a45c49d8-e43e-11e5-91d1-61143f034f84','a45c4ab4-e43e-11e5-91d1-61143f034f84') AND created_at IS NOT NULL
      returns a task

Finished in 22.09 seconds (files took 0.09695 seconds to load)
1 example, 0 failures