### PR TITLE
Add FORCE INDEX(PRIMARY) to UPDATE query not to use timeout as index

### DIFF
--- a/lib/perfectqueue/backend/rdb_compat.rb
+++ b/lib/perfectqueue/backend/rdb_compat.rb
@@ -243,7 +243,7 @@ SQL
             return nil
           end
 
-          sql = "UPDATE `#{@table}` SET timeout=? WHERE timeout <= ? AND id IN ("
+          sql = "UPDATE `#{@table}` FORCE INDEX (PRIMARY) SET timeout=? WHERE timeout <= ? AND id IN ("
           params = [sql, next_timeout, now]
           tasks.each {|t| params << t.key }
           sql << (1..tasks.size).map { '?' }.join(',')


### PR DESCRIPTION
Commit a7dfe18146263ecd01541970041732a09fad39ed adds a condition with timeout
to UPDATE query of acuring tasks.
It also introduced a change for MySQL wrongly to use timeout as index.
With FORCE INDEX(PRIMARY) MySQL correctly use PRIMARY KEY as index.

Also note that index hints for UPDATE query is MySQL 5.5.6 or later http://dev.mysql.com/doc/refman/5.5/en/update.html