### PR TITLE
Randomize initial @cleanup_interval_count

### DIFF
--- a/lib/perfectqueue/backend/rdb_compat.rb
+++ b/lib/perfectqueue/backend/rdb_compat.rb
@@ -105,7 +105,7 @@ SQL
         @prefetch_break_types = config[:prefetch_break_types] || []
 
         @cleanup_interval = config[:cleanup_interval] || DEFAULT_DELETE_INTERVAL
-        @cleanup_interval_count = 0
+        @cleanup_interval_count = rand(@cleanup_interval)
       end
 
       attr_reader :db


### PR DESCRIPTION
If @cleanup_interval is large and starts all workers same time,
cleanup runs periodically in large interval.