### PR TITLE
Run 48's delete query in connect_locked

### DIFF
--- a/lib/perfectqueue/backend/rdb_compat.rb
+++ b/lib/perfectqueue/backend/rdb_compat.rb
@@ -221,10 +221,8 @@ SQL
         if @cleanup_interval_count <= 0
           delete_timeout = now - DELETE_OFFSET
           connect_locked {
-            @db["DELETE FROM `#{@table}` WHERE #{EVENT_HORIZON} < timeout && timeout <= ? AND created_at IS NULL", now].delete
-          }
-          connect { # TODO: HERE should be still connect_locked ?
             t0=Process.clock_gettime(Process::CLOCK_MONOTONIC)
+            @db["DELETE FROM `#{@table}` WHERE #{EVENT_HORIZON} < timeout && timeout <= ? AND created_at IS NULL", now].delete
             @db["DELETE FROM `#{@table}` WHERE timeout <= ? AND created_at IS NULL", delete_timeout].delete
             @cleanup_interval_count = @cleanup_interval
             STDERR.puts"PQ:delete from #{@table}:%6f sec" % [Process.clock_gettime(Process::CLOCK_MONOTONIC)-t0]


### PR DESCRIPTION
To avoid deadlock between 44's and 48's delete query.