### PR TITLE
fix random failure

### DIFF
--- a/spec/rdb_compat_backend_spec.rb
+++ b/spec/rdb_compat_backend_spec.rb
@@ -208,7 +208,7 @@ describe Backend::RDBCompatBackend do
         db.list({}) do |task|
           expect(task.timeout).to eq now0.to_time
         end
-        ary = db.acquire(alive_time, max_acquire, {})
+        ary = db.acquire(alive_time, max_acquire, {now: now})
         expect(ary).to be_an_instance_of(Array)
         expect(ary.size).to eq(3)
         expect(ary[0]).to be_an_instance_of(AcquiredTask)


### PR DESCRIPTION
db.acquire calls `Time.now` in it.
If it is different from `let (:now){ Time.now.to_i }`, the spec will fail.