### PR TITLE
Remove cancel_request

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,6 @@ Queue#[](key)  #=> #<Task>
 # chack the existance of the task
 Task#exists?
 
-# request to cancel a task
-# (actual behavior depends on the worker program)
-Task#cancel_request!
-
 # force finish a task
 # be aware that worker programs can't detect it
 Task#force_finish!
@@ -63,8 +59,6 @@ TaskError
 ##
 # Workers may get these errors:
 #
-
-CancelRequestedError < TaskError
 
 AlreadyFinishedError < TaskError
 
@@ -206,7 +200,6 @@ Usage: perfectqueue [options] <command>
 commands:
     list                             Show list of tasks
     submit <key> <type> <data>       Submit a new task
-    cancel_request <key>             Cancel request
     force_finish <key>               Force finish a task
     run <class>                      Run a worker process
     init                             Initialize a backend database
@@ -242,10 +235,6 @@ options for run:
                                 k2       user_task             user_2            waiting    2012-05-18 13:35:33 -0700    2012-05-18 14:35:33 -0700   {"uid"=>2, "type"=>"user_task"}
                                 k3     system_task                               waiting    2012-05-18 14:04:02 -0700    2012-05-22 15:04:02 -0700   {"task_id"=>32, "type"=>"system_task"}
     3 entries.
-
-### cancel a tasks
-
-    $ perfectqueue cancel_request k1
 
 ### force finish a tasks
 

--- a/lib/perfectqueue/client.rb
+++ b/lib/perfectqueue/client.rb
@@ -69,11 +69,6 @@ module PerfectQueue
       @backend.acquire(alive_time, max_acquire, options)
     end
 
-    # :message => nil
-    def cancel_request(key, options={})
-      @backend.cancel_request(key, options)
-    end
-
     def force_finish(key, options={})
       retention_time = options[:retention_time] || @retention_time
 

--- a/lib/perfectqueue/command/perfectqueue.rb
+++ b/lib/perfectqueue/command/perfectqueue.rb
@@ -8,7 +8,6 @@ op.banner += %[ <command>
 commands:
     list                             Show list of tasks
     submit <key> <type> <data>       Submit a new task
-    cancel_request <key>             Cancel request
     force_finish <key>               Force finish a task
     run <class>                      Run a worker process
     init                             Initialize a backend database
@@ -76,11 +75,6 @@ begin
     cmd = :list
     usage nil unless ARGV.length == 0
 
-  when 'cancel_request' ,'cancel'
-    cmd = :cancel
-    usage nil unless ARGV.length == 1
-    key = ARGV[0]
-
   when 'force_finish' ,'finish'
     cmd = :finish
     usage nil unless ARGV.length == 1
@@ -140,11 +134,6 @@ when :list
     }
   }
   puts "#{n} entries."
-
-when :cancel
-  PerfectQueue.open(config_load_proc.call) {|queue|
-    queue[key].cancel_request!
-  }
 
 when :finish
   PerfectQueue.open(config_load_proc.call) {|queue|

--- a/lib/perfectqueue/task.rb
+++ b/lib/perfectqueue/task.rb
@@ -27,10 +27,6 @@ module PerfectQueue
 
     attr_reader :key
 
-    def cancel_request!(options={})
-      @client.cancel_request(@key, options)
-    end
-
     def force_finish!(options={})
       @client.force_finish(@key, options)
     end

--- a/lib/perfectqueue/task_metadata.rb
+++ b/lib/perfectqueue/task_metadata.rb
@@ -68,10 +68,6 @@ module PerfectQueue
     def running?
       status == TaskStatus::RUNNING
     end
-
-    def cancel_requested?
-      status == TaskStatus::CANCEL_REQUESTED
-    end
   end
 
   class TaskMetadata

--- a/lib/perfectqueue/task_monitor.rb
+++ b/lib/perfectqueue/task_monitor.rb
@@ -147,7 +147,7 @@ module PerfectQueue
     def task_heartbeat
       @task.heartbeat!
     rescue
-      # finished, cancel_requested, preempted, etc.
+      # finished, preempted, etc.
       kill_task($!)
     end
   end
@@ -173,13 +173,6 @@ module PerfectQueue
 
     def retry!(*args, &block)
       @log.info "retry task=#{self.key}" if @log
-      @task_monitor.task_finished(self) {
-        super(*args, &block)
-      }
-    end
-
-    def cancel_request!(*args, &block)
-      @log.info "cancel request task=#{self.key}" if @log
       @task_monitor.task_finished(self) {
         super(*args, &block)
       }

--- a/lib/perfectqueue/task_status.rb
+++ b/lib/perfectqueue/task_status.rb
@@ -21,7 +21,6 @@ module PerfectQueue
     WAITING = :waiting
     RUNNING = :running
     FINISHED = :finished
-    CANCEL_REQUESTED = :cancel_requested
   end
 end
 

--- a/spec/task_monitor_spec.rb
+++ b/spec/task_monitor_spec.rb
@@ -69,9 +69,6 @@ describe PerfectQueue::TaskMonitorHook do
   describe 'retry!' do
     it { task.retry! }
   end
-  describe 'cancel_request!' do
-    it { task.cancel_request! }
-  end
   describe 'update_data!' do
     it { task.update_data!({}) }
   end


### PR DESCRIPTION
cancel_request is not compatible with v0.7's cancel behavior,
and does not work because it doesn't delete canceled tasks.