### PR TITLE
Maintain CI configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 rvm:
-  - 2.1.10
-  - 2.2.5
-  - 2.3.1
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
   - ruby-head
 
 script: "bundle exec rake spec"

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,0 @@
-machine:
-  ruby:
-    version: 2.2.2
-
-database:
-  pre:
-    - mysql -e 'create database perfectqueue_test;'


### PR DESCRIPTION
CircleCI 1.0 is not working anymore, and I don't think it's worth running in addition to Travis.

Also I upgraded Ruby versions tested by Travis. I still kept Ruby 2.3 because somebody may be still using Ruby 2.3.