### PR TITLE
Add sleep lock retrying with exponential-backoff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 rvm:
-  - 2.1.10
-  - 2.2.5
-  - 2.3.1
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
   - ruby-head
 
 script: "bundle exec rake spec"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ rvm:
   - 2.6.3
   - ruby-head
 
+services:
+  - mysql
+
 script: "bundle exec rake spec"
 
 before_script:

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,0 @@
-machine:
-  ruby:
-    version: 2.2.2
-
-database:
-  pre:
-    - mysql -e 'create database perfectqueue_test;'

--- a/lib/perfectqueue/backend/rdb_compat.rb
+++ b/lib/perfectqueue/backend/rdb_compat.rb
@@ -33,6 +33,9 @@ module PerfectQueue
       DELETE_OFFSET = 10_0000_0000
       EVENT_HORIZON = 13_0000_0000 # 2011-03-13 07:06:40 UTC
 
+      LOCK_RETRY_INITIAL_INTERVAL = 0.5
+      LOCK_RETRY_MAX_INTERVAL = 30
+
       class Token < Struct.new(:key)
       end
 
@@ -54,11 +57,14 @@ module PerfectQueue
           end
           @table_lock = lambda {
             locked = nil
+            interval = LOCK_RETRY_INITIAL_INTERVAL
             loop do
               @db.fetch("SELECT GET_LOCK('#{@table}', #{LOCK_WAIT_TIMEOUT}) locked") do |row|
                 locked = true if row[:locked] == 1
               end
               break if locked
+              sleep interval
+              interval = [interval * 2, LOCK_RETRY_MAX_INTERVAL].min
             end
           }
           @table_unlock = lambda {
@@ -115,7 +121,7 @@ SQL
 
       KEEPALIVE = 10
       MAX_RETRY = 10
-      LOCK_WAIT_TIMEOUT = 60
+      LOCK_WAIT_TIMEOUT = 10
       DEFAULT_DELETE_INTERVAL = 20
 
       def init_database(options)


### PR DESCRIPTION
https://github.com/treasure-data/perfectqueue/pull/57 looks wanted to merge https://github.com/treasure-data/perfectqueue/pull/56 to v08 branch which is used by [td-worker](https://github.com/treasure-data/td-worker) but it wrongly merged into master.

This also includes https://github.com/treasure-data/perfectqueue/pull/63.