### PR TITLE
Extract max_retry_count as config parameter

### DIFF
--- a/lib/perfectqueue/backend/rdb.rb
+++ b/lib/perfectqueue/backend/rdb.rb
@@ -21,7 +21,7 @@ module PerfectQueue::Backend
         port: u.port ? u.port.to_i : 3306
       }
       @pq_connect_timeout = config.fetch(:pq_connect_timeout, 20)
-      @max_retry_count = config.fetch(:max_retry_count, 10);
+      @max_retry_count = config.fetch(:max_retry_count, 10)
       options[:connect_timeout] = config.fetch(:connect_timeout, 3)
       options[:sslca] = config[:sslca] if config[:sslca]
       db_name = u.path.split('/')[1]

--- a/lib/perfectqueue/backend/rdb.rb
+++ b/lib/perfectqueue/backend/rdb.rb
@@ -4,7 +4,6 @@ require_relative 'rdb_compat'
 
 module PerfectQueue::Backend
   class RDBBackend
-    MAX_RETRY = ::PerfectQueue::Backend::RDBCompatBackend::MAX_RETRY
     DELETE_OFFSET = ::PerfectQueue::Backend::RDBCompatBackend::DELETE_OFFSET
     class Token < Struct.new(:key)
     end
@@ -22,6 +21,7 @@ module PerfectQueue::Backend
         port: u.port ? u.port.to_i : 3306
       }
       @pq_connect_timeout = config.fetch(:pq_connect_timeout, 20)
+      @max_retry_count = config.fetch(:max_retry_count, 10);
       options[:connect_timeout] = config.fetch(:connect_timeout, 3)
       options[:sslca] = config[:sslca] if config[:sslca]
       db_name = u.path.split('/')[1]
@@ -34,6 +34,7 @@ module PerfectQueue::Backend
     end
 
     attr_reader :db
+    attr_reader :max_retry_count
 
     def submit(id, data, time=Process.clock_gettime(Process::CLOCK_REALTIME, :second), resource=nil, max_running=nil)
       connect {
@@ -63,7 +64,7 @@ module PerfectQueue::Backend
         begin
           yield
         rescue Sequel::DatabaseConnectionError
-          if (retry_count += 1) < MAX_RETRY && tmax > Process.clock_gettime(Process::CLOCK_REALTIME, :second)
+          if (retry_count += 1) < @max_retry_count && tmax > Process.clock_gettime(Process::CLOCK_REALTIME, :second)
             STDERR.puts "#{$!}\n  retrying."
             sleep 2
             retry
@@ -75,7 +76,7 @@ module PerfectQueue::Backend
           if $!.to_s.include?('try restarting transaction')
             err = $!.backtrace.map{|bt| "  #{bt}" }.unshift($!).join("\n")
             retry_count += 1
-            if retry_count < MAX_RETRY
+            if retry_count < @max_retry_count
               STDERR.puts "#{err}\n  retrying."
               sleep 0.5
               retry

--- a/lib/perfectqueue/backend/rdb_compat.rb
+++ b/lib/perfectqueue/backend/rdb_compat.rb
@@ -43,7 +43,7 @@ module PerfectQueue
         super
 
         @pq_connect_timeout = config.fetch(:pq_connect_timeout, 20)
-        @max_retry_count = config.fetch(:max_retry_count, 10);
+        @max_retry_count = config.fetch(:max_retry_count, 10)
         url = config[:url]
         @table = config[:table]
         unless @table

--- a/lib/perfectqueue/backend/rdb_compat.rb
+++ b/lib/perfectqueue/backend/rdb_compat.rb
@@ -43,6 +43,7 @@ module PerfectQueue
         super
 
         @pq_connect_timeout = config.fetch(:pq_connect_timeout, 20)
+        @max_retry_count = config.fetch(:max_retry_count, 10);
         url = config[:url]
         @table = config[:table]
         unless @table
@@ -121,9 +122,9 @@ SQL
       end
 
       attr_reader :db
+      attr_reader :max_retry_count
 
       KEEPALIVE = 10
-      MAX_RETRY = 10
       LOCK_WAIT_TIMEOUT = 10
       DEFAULT_DELETE_INTERVAL = 20
 
@@ -373,7 +374,7 @@ SQL
             yield
             @last_time = now
           rescue Sequel::DatabaseConnectionError
-            if (count += 1) < MAX_RETRY && tmax > Time.now.to_i
+            if (count += 1) < @max_retry_count && tmax > Time.now.to_i
               STDERR.puts "#{$!}\n  retrying."
               sleep 2
               retry
@@ -385,7 +386,7 @@ SQL
             if $!.to_s.include?('try restarting transaction')
               err = ([$!] + $!.backtrace.map {|bt| "  #{bt}" }).join("\n")
               count += 1
-              if count < MAX_RETRY
+              if count < @max_retry_count
                 STDERR.puts err + "\n  retrying."
                 sleep rand
                 retry

--- a/spec/rdb_backend_spec.rb
+++ b/spec/rdb_backend_spec.rb
@@ -55,7 +55,7 @@ describe Backend::RDBBackend do
     end
     context 'error' do
       it 'returns block result' do
-        expect(RuntimeError).to receive(:new).exactly(Backend::RDBBackend::MAX_RETRY).and_call_original
+        expect(RuntimeError).to receive(:new).exactly(db.max_retry_count).and_call_original
         allow(STDERR).to receive(:puts)
         allow(db).to receive(:sleep)
         expect do

--- a/spec/rdb_compat_backend_spec.rb
+++ b/spec/rdb_compat_backend_spec.rb
@@ -367,7 +367,7 @@ describe Backend::RDBCompatBackend do
     end
     context 'error' do
       it 'returns block result' do
-        expect(RuntimeError).to receive(:new).exactly(Backend::RDBCompatBackend::MAX_RETRY).and_call_original
+        expect(RuntimeError).to receive(:new).exactly(db.max_retry_count).and_call_original
         allow(STDERR).to receive(:puts)
         allow(db).to receive(:sleep)
         expect do


### PR DESCRIPTION
This PR introduces new config parameter :max_retry_count to customize the threshold of connect error retry. In the current implementation, the retry count is hard-coded in backend/{rdb,rdb_compat}.rb. It should be extracted to make it customizable for each environment.