### PR TITLE
Support ssl_mode option for RDBBackend

### DIFF
--- a/lib/perfectqueue/backend/rdb.rb
+++ b/lib/perfectqueue/backend/rdb.rb
@@ -24,6 +24,7 @@ module PerfectQueue::Backend
       @pq_connect_timeout = config.fetch(:pq_connect_timeout, 20)
       options[:connect_timeout] = config.fetch(:connect_timeout, 3)
       options[:sslca] = config[:sslca] if config[:sslca]
+      options[:ssl_mode] = config[:ssl_mode] if config[:ssl_mode]
       db_name = u.path.split('/')[1]
       @db = Sequel.mysql2(db_name, options)
 

--- a/perfectqueue.gemspec
+++ b/perfectqueue.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake", "~> 0.9.2"
   gem.add_development_dependency "rspec", "~> 3.3.0"
   gem.add_development_dependency "simplecov", "~> 0.10.0"
-  gem.add_development_dependency "mysql2", ">= 0.3.20"
+  gem.add_development_dependency "mysql2", ">= 0.4.5"
 end

--- a/spec/rdb_backend_spec.rb
+++ b/spec/rdb_backend_spec.rb
@@ -28,6 +28,9 @@ describe Backend::RDBBackend do
         end.and_call_original
         Backend::RDBBackend.new(uri, table, ssl_mode: :disabled)
       end
+      it 'invalid value causes error' do
+        expect { Backend::RDBBackend.new(uri, table, ssl_mode: :invalid) }.to raise_error(Sequel::DatabaseConnectionError)
+      end
     end
   end
 

--- a/spec/rdb_backend_spec.rb
+++ b/spec/rdb_backend_spec.rb
@@ -17,6 +17,9 @@ describe Backend::RDBBackend do
     it 'supports mysql' do
       expect(Backend::RDBBackend.new(uri, table)).to be_an_instance_of(Backend::RDBBackend)
     end
+    it "accepts ssl_mode as an option" do
+      expect(Backend::RDBBackend.new(uri, table, ssl_mode: :disabled).db.opts[:ssl_mode]).to eq(:disabled)
+    end
   end
 
   context '#submit' do

--- a/spec/rdb_backend_spec.rb
+++ b/spec/rdb_backend_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'perfectqueue/backend/rdb'
+require 'mysql2'
 
 describe Backend::RDBBackend do
   let (:now){ Time.now.to_i }
@@ -17,8 +18,16 @@ describe Backend::RDBBackend do
     it 'supports mysql' do
       expect(Backend::RDBBackend.new(uri, table)).to be_an_instance_of(Backend::RDBBackend)
     end
-    it "accepts ssl_mode as an option" do
-      expect(Backend::RDBBackend.new(uri, table, ssl_mode: :disabled).db.opts[:ssl_mode]).to eq(:disabled)
+
+    describe 'supports ssl_mode as an option' do
+      let (:uri){ 'mysql2://root:@127.0.0.1/perfectqueue_test' }
+
+      it 'passes ssl_mode to Mysql2::Client initializer' do
+        expect(Mysql2::Client).to receive(:new) do |params|
+          expect(params[:ssl_mode]).to be(:disabled)
+        end.and_call_original
+        Backend::RDBBackend.new(uri, table, ssl_mode: :disabled)
+      end
     end
   end
 


### PR DESCRIPTION
We want to control `ssl_mode` option in some cases.